### PR TITLE
 Status bar lyrics: Fix bug where some lyric would be wrongly ignored

### DIFF
--- a/packages/SystemUI/src/com/android/systemui/statusbar/phone/LyricViewController.java
+++ b/packages/SystemUI/src/com/android/systemui/statusbar/phone/LyricViewController.java
@@ -114,8 +114,7 @@ public abstract class LyricViewController implements
         if (!mEnabled) return;
 
         Notification notification = sbn.getNotification();
-        boolean isLyric = ((notification.flags & Notification.FLAG_ALWAYS_SHOW_TICKER) != 0)
-                && ((notification.flags & Notification.FLAG_ONLY_UPDATE_TICKER) != 0);
+        boolean isLyric = (notification.flags & Notification.FLAG_ALWAYS_SHOW_TICKER) != 0;
 
         boolean isCurrentNotification = mCurrentNotificationId == sbn.getId() &&
                 TextUtils.equals(sbn.getPackageName(), mCurrentNotificationPackage);


### PR DESCRIPTION
FLAG_ONLY_UPDATE_TICKER may not always be set by the app because it will prevent update of notification content in Flyme OS, follow Flyme OS behaviour to classify what lyric is